### PR TITLE
Jekyll 3+ support, updated documentation, and more...

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,23 @@ Jekyll Multiple Languages is an internationalization plugin for [Jekyll](https:/
 
 The plugin is developed as an utility at [Screen Interaction](http://www.screeninteraction.com)
 
-##Installation
-
 ### Gem [![Gem Version](https://badge.fury.io/rb/jekyll-multiple-languages-plugin.png)](http://badge.fury.io/rb/jekyll-multiple-languages-plugin)
+
+
+## Features
+* Supports multiple languages with the same code base.
+* Supports all template languages that your Liquid pipeline supports.
+* Uses [Liquid tags](https://github.com/Shopify/liquid) in your HTML for including translated strings.
+* Compiles the site multiple times for all supported languages into separate subfolders.
+* The plugin even works with the -watch flag turned on and will rebuild all languages automatically.
+* Contains an example web site thanks to [@davrandom](https://github.com/davrandom/)
+* Supports translated keys in YAML format
+* Supports translated template files
+* Supports translated links
+
+
+
+## Installation
 
 This plugin is available as a Rubygem, https://rubygems.org/gems/jekyll-multiple-languages-plugin.
 
@@ -20,49 +34,19 @@ And then execute: `$ bundle`
 
 Or install it yourself as: `$ gem install jekyll-multiple-languages-plugin`
 
-To activate the plugin add this line in to a *.rb file in the _plugins directory:
+To activate the plugin add it to the Jekyll `_config.yml` file, under the `gems` option:
 
 ```ruby
-require 'jekyll/multiple/languages/plugin'
+gems: 
+  - jekyll/multiple/languages/plugin
 ```
+See the [Jekyll configuration documentation](http://jekyllrb.com/docs/configuration) for details.
 
 
-### Submodule
-If your Jekyll project is in a git repository, you can easily
-manage your plugins by utilizing git submodules.
 
-To install this plugin as a git submodule:
-
-```sh
-$ git submodule add git://github.com/screeninteraction/jekyll-multiple-languages-plugin.git _plugins/multiple-languages
-```
-
-To update:
-
-```sh
-$ cd _plugins/multiple-languages
-$ git pull origin master
-```
-
-
-### Copy file
-Copy or link the file `lib/jekyll/multiple/languages/plugin.rb` into your `_plugins` folder for your Jekyll project.
-
-
-##Features
-* Supports multiple languages with the same code base.
-* Supports all template languages that your Liquid pipeline supports.
-* Uses [Liquid tags](https://github.com/Shopify/liquid) in your HTML for including translated strings.
-* Compiles the site multiple times for all supported languages into separate subfolders.
-* The plugin even works with the -watch flag turned on and will rebuild all languages automatically.
-* Contains an example web site thanks to [@davrandom](https://github.com/davrandom/)
-* Supports translated keys in YAML format
-* Supports translated template files
-
-
-##Usage
-###Configuration
-Add the i18n configuration to your _config.yml:
+## Usage
+### Configuration
+Add the i18n configuration to your _config.yml (obligatory):
 
 ```yaml
 languages: ["sv", "en", "de", "fr"]
@@ -70,19 +54,19 @@ languages: ["sv", "en", "de", "fr"]
 
 The first language in the array will be the default language, English, German and French will be added in to separate subfolders.
 
-To avoid redundancy, it is possible to exclude files and folders from beeing copied to the localization folders.
+To avoid redundancy, it is possible to exclude files and folders from being copied to the localization folders.
 
 ```yaml
 exclude_from_localizations: ["javascript", "images", "css"]
 ```
-In code these specific files should be referenced via `baseurl_root`. E.g.
+In code, these specific files should be referenced via `baseurl_root`. E.g.
 
 ```
 <link rel="stylesheet" href="{{ "/css/bootstrap.css" | prepend: site.baseurl_root }}"/>
 ```
 
-###i18n
-Create this folder structure in your Jekyll project as an example:
+### Folder structure
+Create a folder called `_i18n` and add sub-folders for each language, using the same names used on the `languages` setting on the `_config.yml`:
 
   - /_i18n/sv.yml
   - /_i18n/en.yml
@@ -93,7 +77,8 @@ Create this folder structure in your Jekyll project as an example:
   - /_i18n/de/pagename/blockname.md
   - /_i18n/fr/pagename/blockname.md
 
-To add a string to your site use one of these
+### Translating strings
+To add a translated string into your web page use one of these liquid tags.
 
 ```liquid
 {% t key %}
@@ -101,7 +86,7 @@ or
 {% translate key %}
 ```
 
-Liquid tags. This will pick the correct string from the `language.yml` file during compilation.
+This will pick the correct string from the `language.yml` file during compilation.
 
 The language.yml files are written in YAML syntax which caters for a simple grouping of strings.
 
@@ -122,7 +107,8 @@ or
 {% translate global.english %}
 ```
 
-The plugin also supports using different markdown files for different languages using the
+### Translating long texts
+The plugin also supports using different markdown files for different languages using the liquid tag:
 
 ```liquid
 {% tf pagename/blockname.md %}
@@ -130,15 +116,24 @@ or
 {% translate_file pagename/blockname.md %}
 ```
 
-This plugin have exactly the same support and syntax as the built in
+This plugin have exactly the same support and syntax as the built in liquid tag:
 
 ```liquid
 {% include file %}
 ```
 
-tag, so plugins that extends its functionality should be picked up by this plugin as well.
+so plugins that extends its functionality should be picked up by this plugin as well.
 
-###i18n in templates
+### Translating links
+You can translate links using the liquid tag:
+
+```liquid
+{% tl /something/ lang %}
+or
+{% translate_link /something/ lang %}
+```
+
+### i18n in templates
 Sometimes it is convenient to add keys even in template files. This works in the exact same way as in ordinary files, however sometimes it can be useful to include different string in different pages even if they use the same template.
 
 A perfect example is this:
@@ -167,7 +162,9 @@ titles:
 	home: "Home"
 ```
 
-##Link between languages
+
+
+## Link between languages
 This plugin gives you the variables
 
 ```liquid
@@ -203,7 +200,48 @@ This snippet will create a link that will toggle between Swedish and English. A 
 | page.url | The current page's relative URL to the baseurl | ``` /a/sub/folder/page/ ```|
 
 
-##Changelog
+
+## Example website
+
+This repository has an example website where you can test the plugin.
+After downloading the repository, get into the `example` directory and run: `bundle install` to install the newest version of Jekyll (change the Gemfile to install another version), the plugin, and all other dependencies.
+
+Then run `bundle exec jekyll serve` to start the Jekyll server and using your web browser, access the address `http://localhost:4000`.
+
+### Adding a new language
+
+Imagine you want to add German pages on the test website. First, add a the new language into the list of languages on `_config.yml`:
+```ruby
+languages: ["it", "en", "es", "de"]
+```
+
+Create a new folder for the language under the `_i18n` folder and add a markdown file containing the translation, just like on the other languages folders, and you're done.
+
+### Adding a file
+
+Let's say you want to create an about page for the example website, you will create an `about.html` page on the root of the website (same place as index.html), with this:
+
+```
+---
+layout: page
+title: About
+permalink: /about/
+---
+
+{% translate_file about/about.md %}
+```
+
+Then, create a file named `about.md` under `_i18n/en` with the English content. Repeat this for the other languages (_i18n/es/about.md ...). When running the website, visit the address `http://localhost:4000/about` to see the English version, `http://localhost:4000/es/about` for the Spanish one, etc.
+
+
+
+## Changelog
+* 1.4.0
+  * Support for Jekyll 3.0+, thanks to [@Anthony-Gaudino]() --- Please link to my pull request!
+  * Colored messages, thanks to [@Anthony-Gaudino]() --- Please link to my pull request!
+  * _config.yml settings checks, thanks to [@Anthony-Gaudino]() --- Please link to my pull request!
+  * Removed .htaccess from language folders, thanks to [@Anthony-Gaudino]() --- Please link to my pull request!
+  * ":categories" in permalinks fix for Jekyll 2, thanks to [@mohamnag](https://github.com/screeninteraction/jekyll-multiple-languages-plugin/issues/38)
 * 1.3.0
   * Support for localized links and custom permalinks, thanks to [@jasonlemay](https://github.com/screeninteraction/jekyll-multiple-languages-plugin/pull/53)
   * Support for excluding posts from translation, thanks to [@ctruelson](https://github.com/screeninteraction/jekyll-multiple-languages-plugin/pull/51)
@@ -247,6 +285,7 @@ This snippet will create a link that will toggle between Swedish and English. A 
 5. Create new Pull Request
 
 ### Contributors
+- [@Anthony-Gaudino](https://github.com/Anthony-Gaudino), support for Jekyll 3, improved documentation, example website works with newer versions of Jekyll, code formatting, colored messages, and more.
 - [@jasonlemay](https://github.com/jasonlemay), support for localized links
 - [@ctruelson](https://github.com/ctruelson), support for excluding posts
 - [@Bersch](https://github.com/bersch), better paths

--- a/example/Gemfile
+++ b/example/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
+
 gem "jekyll"
 gem 'jekyll-multiple-languages-plugin'
-
+gem "redcarpet"

--- a/example/_config.yml
+++ b/example/_config.yml
@@ -1,8 +1,16 @@
 name: Flex
 markdown: redcarpet
-pygments: true
+highlighter: pygments
 
 baseurl: ""
 permalink: /:title/
 
+# Plugins
+gems: 
+  - jekyll/multiple/languages/plugin
+
+
+# jekyll-multiple-languages-plugin settings:
 languages: ["it", "en", "es"]
+
+exclude_from_localizations: ["javascript", "images", "css", "Gemfile", "scripts", "favicon.ico", "LICENSE", "README.md"]

--- a/example/_plugins/jekyll-multiple-languages-plugin.rb
+++ b/example/_plugins/jekyll-multiple-languages-plugin.rb
@@ -1,1 +1,0 @@
-require 'jekyll/multiple/languages/plugin'

--- a/jekyll-multiple-languages-plugin.gemspec
+++ b/jekyll-multiple-languages-plugin.gemspec
@@ -20,4 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake", "~> 0"
+  
+  spec.add_runtime_dependency "colorator"
 end

--- a/lib/jekyll/multiple/languages/plugin.rb
+++ b/lib/jekyll/multiple/languages/plugin.rb
@@ -1,71 +1,243 @@
+=begin
+Jekyll Multiple Languages is an internationalization plugin for Jekyll. It
+compiles your Jekyll site for one or more languages with a similar approach as
+Rails does. The different sites will be stored in sub folders with the same name
+as the language it contains.
+
+Please visit https://github.com/screeninteraction/jekyll-multiple-languages-plugin
+for more details.
+=end
+
+
 require "jekyll/multiple/languages/plugin/version"
+require "colorator"
 
 module Jekyll
+  # Hash that stores a list of language translations read from an YAML file.
   @parsedlangs = {}
+
+  #======================================
+  # self.langs
+  #
+  # Returns the list of translations.
+  #======================================
   def self.langs
     @parsedlangs
   end
+
+  #======================================
+  # self.setlangs
+  #
+  # Set the list of translations.
+  #======================================
   def self.setlangs(l)
     @parsedlangs = l
   end
+
+
+
+#===============================================================================
+  # Boolean that stores if the _posts folder will not be included for localizations
+  # True if it is not included, false otherwise.
+  @translateposts = true
+  
+  #======================================
+  # self.transposts
+  #
+  # Returns if _posts folder will not be included for localizations
+  #======================================
+  def self.transposts
+    @translateposts
+  end
+
+  #======================================
+  # self.settransposts
+  #
+  # Set the _posts folder will not be included for localizations
+  #======================================
+  def self.settransposts(t)
+    @translateposts = t
+  end
+
+
+
+#===============================================================================
+  # The current language that is being processed.
+  @currentlanguage = ""
+  
+  #======================================
+  # self.currlang
+  #
+  # Returns the current language being processed.
+  #======================================
+  def self.currlang
+    @currentlanguage
+  end
+
+  #======================================
+  # self.currlang
+  #
+  # Set the current language being processed.
+  #======================================
+  def self.setcurrlang(l)
+    @currentlanguage = l
+  end
+
+
+
+  ##############################################################################
+  # class Site
+  ##############################################################################
   class Site
     alias :process_org :process
+    
+    
+    
+    #======================================
+    # process
+    #
+    # Reads Jekyll and plugin configuration parameters set on _config.yml, sets
+    # main parameters and processes the website for each language.
+    #======================================
     def process
+      # Check if some importat settings are set, if not, set a default or quit.
+      #-------------------------------------------------------------------------
       if !self.config['baseurl']
-        self.config['baseurl'] = ""
+          self.config['baseurl'] = ""
       end
-      #Variables
-      config['baseurl_root'] = self.config['baseurl']
-      baseurl_org = self.config['baseurl']
-      languages = self.config['languages']
-      exclude_org = self.exclude
-      dest_org = self.dest
-
-      #Loop
+      
+      if !self.config['exclude_from_localizations']
+          self.config['exclude_from_localizations'] = []
+      end
+      
+      if !self.config['languages'] or !self.config['languages'].any?
+          puts "Jekyll Multiple Languages: ".bold + "You must provide at least one language using the 'languages' setting on your _config.yml.".red
+          exit
+      end
+      
+      
+      # Variables
+      #-------------------------------------------------------------------------
+      config['baseurl_root'] = self.config[ 'baseurl' ] # baseurl set on _config.yml
+      baseurl_org            = self.config[ 'baseurl' ] # baseurl set on _config.yml
+      languages              = self.config['languages'] # List of languages set on _config.yml
+      exclude_org            = self.exclude             # List of excluded paths
+      dest_org               = self.dest                # Destination folder where the website is generated
+      
+      Jekyll.settransposts(!self.config['exclude_from_localizations'].include?("_posts"))
+      
+      
+      
+      # Build the website for default language
+      #-------------------------------------------------------------------------
       self.config['lang'] = self.config['default_lang'] = languages.first
+      
+      Jekyll.setcurrlang(self.config['lang'])
+      
       puts
-      puts "Building site for default language: \"#{self.config['lang']}\" to: #{self.dest}"
+      puts "Jekyll Multiple Languages: ".bold + "Building site for default language: \"#{self.config['lang']}\" to: #{self.dest}".blue
+      
       process_org
+      
+      # Remove .htaccess file from included files, so it wont show up on translations folders.
+      # https://github.com/screeninteraction/jekyll-multiple-languages-plugin/issues/47
+      self.include -= [".htaccess"]
+      
+      # Build the website for the other languages
+      #.........................................................................
       languages.drop(1).each do |lang|
 
         # Build site for language lang
-        @dest = @dest + "/" + lang
+        @dest                  = @dest                  + "/" + lang
         self.config['baseurl'] = self.config['baseurl'] + "/" + lang
-        self.config['lang'] = lang
+        self.config['lang']    =                                lang
 
         # exclude folders or files from being copied to all the language folders
-        exclude_from_localizations = self.config['exclude_from_localizations'] || []
-        @exclude = @exclude + exclude_from_localizations
+        exclude_from_localizations = self.config['exclude_from_localizations']
+        @exclude                   =   @exclude + exclude_from_localizations
 
-        puts "Building site for language: \"#{self.config['lang']}\" to: #{self.dest}"
+        Jekyll.setcurrlang(lang)
+
+        puts "Jekyll Multiple Languages: ".bold + "Building site for language: \"#{self.config['lang']}\" to: #{self.dest}".blue
         process_org
 
         #Reset variables for next language
-        @dest = dest_org
+        @dest    =    dest_org
         @exclude = exclude_org
 
         self.config['baseurl'] = baseurl_org
       end
-      Jekyll.setlangs({})
-      puts 'Build complete'
+      
+      Jekyll.setlangs(      {} )
+      Jekyll.settransposts(true)
+      Jekyll.setcurrlang(   "" )
+      
+      puts 'Build complete'.green
     end
-
-    alias :read_posts_org :read_posts
-    def read_posts(dir)
-      translate_posts = !self.config['exclude_from_localizations'].include?("_posts")
-      if dir == '' && translate_posts
-        read_posts("_i18n/#{self.config['lang']}/")
-      else
-        read_posts_org(dir)
+    
+    
+    
+    # For Jekyll version < 3. We check if this method is defined, this method
+    # was deprecated on version 3+.
+    if Site.method_defined?   :read_posts
+        alias :read_posts_org :read_posts
+      
+      #======================================
+      # read_posts
+      #======================================
+      def read_posts(dir)
+        translate_posts = !self.config['exclude_from_localizations'].include?("_posts")
+        
+        if dir == '' && translate_posts
+          read_posts("_i18n/#{self.config['lang']}/")
+        else
+          read_posts_org(dir)
+        end
       end
     end
+    
   end
 
+
+
+  ##############################################################################
+  # class Reader
+  ##############################################################################
+  class Reader
+    # For Jekyll version 3+. We check if this method is defined, this method
+    # replaces the deprecated read_posts method used on old versions.
+    if Reader.method_defined?   :retrieve_posts
+      alias :retrieve_posts_org :retrieve_posts
+      
+      #======================================
+      # retrieve_posts
+      #======================================
+      def retrieve_posts(dir)
+        if dir == '' && Jekyll.transposts
+          site.posts.docs.concat(PostReader.new(site).read_posts( "_i18n/#{Jekyll.currlang}/"))
+          site.posts.docs.concat(PostReader.new(site).read_drafts("_i18n/#{Jekyll.currlang}/")) if site.show_drafts
+        else
+          retrieve_posts_org(dir)
+        end
+      end
+    end
+  
+  end
+
+
+  ##############################################################################
+  # class Page
+  ##############################################################################
   class Page
+
+    #======================================
+    # permalink
+    #======================================
     def permalink
       return nil if data.nil? || data['permalink'].nil?
+      
       if site.config['relative_permalinks']
-        File.join(@dir, data['permalink'])
+        File.join(@dir,  data['permalink'])
       else
         # Look if there's a permalink overwrite specified for this lang
         data['permalink_'+site.config['lang']] || data['permalink']
@@ -73,136 +245,239 @@ module Jekyll
     end
   end
 
-  class LocalizeTag < Liquid::Tag
 
+
+  ##############################################################################
+  # class LocalizeTag
+  #
+  # Localization by getting localized text from YAML files.
+  # User must use the "t" or "translate" liquid tags.
+  ##############################################################################
+  class LocalizeTag < Liquid::Tag
+    #======================================
+    # initialize
+    #======================================
     def initialize(tag_name, key, tokens)
       super
       @key = key.strip
     end
-
+    
+    
+    
+    #======================================
+    # render
+    #======================================
     def render(context)
-      if "#{context[@key]}" != "" #Check for page variable
+      if      "#{context[@key]}" != "" # Check for page variable
         key = "#{context[@key]}"
       else
-        key = @key
+        key =            @key
       end
+      
       lang = context.registers[:site].config['lang']
+      
       unless Jekyll.langs.has_key?(lang)
-        puts "Loading translation from file #{context.registers[:site].source}/_i18n/#{lang}.yml"
-        Jekyll.langs[lang] = YAML.load_file("#{context.registers[:site].source}/_i18n/#{lang}.yml")
+        puts "Jekyll Multiple Languages: ".bold + "Loading translation from file #{context.registers[:site].source}/_i18n/#{lang}.yml".blue
+        Jekyll.langs[lang] = YAML.load_file(                                    "#{context.registers[:site].source}/_i18n/#{lang}.yml")
       end
+      
       translation = Jekyll.langs[lang].access(key) if key.is_a?(String)
+      
       if translation.nil? or translation.empty?
-        translation = Jekyll.langs[context.registers[:site].config['default_lang']].access(key)
-        puts "Missing i18n key: #{lang}:#{key}"
-        puts "Using translation '%s' from default language: %s" %[translation, context.registers[:site].config['default_lang']]
+         translation = Jekyll.langs[context.registers[:site].config['default_lang']].access(key)
+        
+        puts "Jekyll Multiple Languages: ".bold + "Missing i18n key: #{lang}:#{key}".yellow
+        puts "Using translation '%s' from default language: %s" %[translation, context.registers[:site].config['default_lang']].yellow
       end
+      
       translation
     end
   end
 
+
+
+  ##############################################################################
+  # class LocalizeInclude
+  #
+  # Localization by including whole files that contain the localization text.
+  # User must use the "tf" or "translate_file" liquid tags.
+  ##############################################################################
   module Tags
     class LocalizeInclude < IncludeTag
+    
+      #======================================
+      # render
+      #======================================
       def render(context)
-        if "#{context[@file]}" != "" #Check for page variable
+        if       "#{context[@file]}" != "" # Check for page variable
           file = "#{context[@file]}"
         else
-          file = @file
+          file =            @file
         end
 
         includes_dir = File.join(context.registers[:site].source, '_i18n/' + context.registers[:site].config['lang'])
 
         if File.symlink?(includes_dir)
-          return "Includes directory '#{includes_dir}' cannot be a symlink"
+          puts "Jekyll Multiple Languages: ".bold + "Includes directory '#{includes_dir}' cannot be a symlink".red
+          return                                    "Includes directory '#{includes_dir}' cannot be a symlink"
         end
+        
         if file !~ /^[a-zA-Z0-9_\/\.-]+$/ || file =~ /\.\// || file =~ /\/\./
-          return "Include file '#{file}' contains invalid characters or sequences"
+          puts "Jekyll Multiple Languages: ".bold + "Include file '#{file}' contains invalid characters or sequences".red
+          return                                    "Include file '#{file}' contains invalid characters or sequences"
         end
 
         Dir.chdir(includes_dir) do
           choices = Dir['**/*'].reject { |x| File.symlink?(x) }
+          
           if choices.include?(file)
-            source = File.read(file)
+            source  = File.read(file)
             partial = Liquid::Template.parse(source)
 
             context.stack do
-              context['include'] = parse_params(context) if @params
-              contents = partial.render(context)
-              site = context.registers[:site]
-              ext = File.extname(file)
+              context['include'] = parse_params(  context) if @params
+              contents           = partial.render(context)
+              site               = context.registers[:site]
+              ext                = File.extname(file)
 
               converter = site.converters.find { |c| c.matches(ext) }
-              contents = converter.convert(contents) unless converter.nil?
+              contents  = converter.convert(contents) unless converter.nil?
 
               contents
             end
           else
-            "Included file '#{file}' not found in #{includes_dir} directory"
+            puts "Jekyll Multiple Languages: ".bold + "Included file '#{file}' not found in #{includes_dir} directory".red
+            return                                    "Included file '#{file}' not found in #{includes_dir} directory"
           end
         end
       end
     end
   end
 
+
+
+  ##############################################################################
+  # class LocalizeLink
+  #
+  # Creates links or permalinks for translated pages.
+  # User must use the "tl" or "translate_link" liquid tags.
+  ##############################################################################
   class LocalizeLink < Liquid::Tag
 
+    #======================================
+    # initialize
+    #======================================
     def initialize(tag_name, key, tokens)
       super
       @key = key
     end
-
+    
+    
+    
+    #======================================
+    # render
+    #======================================
     def render(context)
-      if "#{context[@key]}" != "" #Check for page variable
+      if      "#{context[@key]}" != "" # Check for page variable
         key = "#{context[@key]}"
       else
         key = @key
       end
-      key = key.split
-      namespace = key[0]
-      lang = key[1] || context.registers[:site].config['lang']
-      default_lang = context.registers[:site].config['default_lang']
-      baseurl = context.registers[:site].baseurl
-      pages = context.registers[:site].pages
-      url = "";
-
+      
+      key          = key.split
+      namespace    = key[0]
+      lang         = key[1] || context.registers[:site].config[        'lang']
+      default_lang =           context.registers[:site].config['default_lang']
+      baseurl      =           context.registers[:site].baseurl
+      pages        =           context.registers[:site].pages
+      url          = "";
+      
       if default_lang != lang
         baseurl = baseurl + "/" + lang
       end
-
+      
       for p in pages
-        unless p['namespace'].nil?
+        unless             p['namespace'].nil?
           page_namespace = p['namespace']
+          
           if namespace == page_namespace
             permalink = p['permalink_'+lang] || p['permalink']
-            url = baseurl + permalink
+            url       = baseurl + permalink
           end
         end
       end
+      
       url
     end
   end
-end
+  
+  
+  
+  ##############################################################################
+  # class Hash
+  ##############################################################################
+  class Post
+    # For Jekyll version < 3. We check if this method is defined, this method
+    # replaces the deprecated populate_categories method used on old versions.
+    if Post.method_defined?   :populate_categories
+      alias :populate_categories_org :populate_categories
+      
+      #======================================
+      # populate_categories
+      #======================================
+      def populate_categories
+        cats = Array(categories);
 
+        x = cats.index("_i18n")
+        cats.delete_at(x) unless x.nil?
+
+        x = cats.index(site.config['lang'])
+        cats.delete_at(x) unless x.nil?
+
+        self.categories = cats
+
+        populate_categories_org
+      end
+    end
+  end
+  
+  
+end # End module Jekyll
+
+
+
+################################################################################
+# class Hash
+################################################################################
 unless Hash.method_defined? :access
   class Hash
     def access(path)
       ret = self
       path.split('.').each do |p|
+      
         if p.to_i.to_s == p
           ret = ret[p.to_i]
         else
           ret = ret[p.to_s] || ret[p.to_sym]
         end
+        
         break unless ret
       end
+      
       ret
     end
   end
 end
 
-Liquid::Template.register_tag('t', Jekyll::LocalizeTag)
-Liquid::Template.register_tag('translate', Jekyll::LocalizeTag)
-Liquid::Template.register_tag('tf', Jekyll::Tags::LocalizeInclude)
+
+
+################################################################################
+# Liquid tags definitions
+
+Liquid::Template.register_tag('t',              Jekyll::LocalizeTag          )
+Liquid::Template.register_tag('translate',      Jekyll::LocalizeTag          )
+Liquid::Template.register_tag('tf',             Jekyll::Tags::LocalizeInclude)
 Liquid::Template.register_tag('translate_file', Jekyll::Tags::LocalizeInclude)
-Liquid::Template.register_tag('tl', Jekyll::LocalizeLink)
-Liquid::Template.register_tag('translate_link', Jekyll::LocalizeLink)
+Liquid::Template.register_tag('tl',             Jekyll::LocalizeLink         )
+Liquid::Template.register_tag('translate_link', Jekyll::LocalizeLink         )
+

--- a/lib/jekyll/multiple/languages/plugin/version.rb
+++ b/lib/jekyll/multiple/languages/plugin/version.rb
@@ -2,7 +2,7 @@ module Jekyll
   module Multiple
     module Languages
       module Plugin
-        VERSION = "1.3.0"
+        VERSION = "1.4.0"
       end
     end
   end


### PR DESCRIPTION
* Plugin is now compatible with Jekyll 3+

* Updated example website to work with newer versions of Jekyll.

* Better code formatting and more comments.

* Added a gem dependency "colorator", which is also used by Jekyll and Octopress, and allows to show colorized messages. Added color to messages.

* If there is no "languages" set on _config.yml or it's empty, a message is displayed and program is terminated.

* Documented on README.md how to create a new page on the example website (https://github.com/screeninteraction/jekyll-multiple-languages-plugin/issues/48)

* Removed suggestion to use submodule on README.md, it's much better to use the gem alongside Bundler (https://github.com/screeninteraction/jekyll-multiple-languages-plugin/issues/40)

* Code now makes "exclude_from_localizations" option on _config.yml optional (https://github.com/screeninteraction/jekyll-multiple-languages-plugin/issues/54)

* Removed .htaccess from translations folders (https://github.com/screeninteraction/jekyll-multiple-languages-plugin/issues/47)

* Implements the ":categories" in permalinks fix proposed by @mohamnag. This fix is only for Jekyll 2. (https://github.com/screeninteraction/jekyll-multiple-languages-plugin/issues/38)

-----
I changed version to 1.4.0.

Please review the changes.

If accepted, please add a link to my push request on the README.md.

Thank you!