### PR TITLE
Correct variable which provides the language of a page

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ titles:
 This plugin gives you the variables
 
 ```liquid
-{{ page.lang }}
+{{ site.lang }}
 
 and
 


### PR DESCRIPTION
@Anthony-Gaudino This fixes an error in the instructions on how to use the plugin. This caused quite a confusion in my project since I was already using a variable `{{ page.lang }}` which always returned en even though the translations were correct.