### PR TITLE
Handle cases where baseurl is not present in config

### DIFF
--- a/lib/jekyll-multiple-languages-plugin.rb
+++ b/lib/jekyll-multiple-languages-plugin.rb
@@ -87,8 +87,8 @@ module Jekyll
       #-------------------------------------------------------------------------
       
       # Original Jekyll configurations
-      baseurl_org                 = self.config[ 'baseurl' ] # Baseurl set on _config.yml
-      dest_org                    = self.dest                # Destination folder where the website is generated
+      baseurl_org                 = self.config[ 'baseurl' ].to_s # Baseurl set on _config.yml
+      dest_org                    = self.dest                     # Destination folder where the website is generated
       
       # Site building only variables
       languages                   = self.config['languages'] # List of languages set on _config.yml


### PR DESCRIPTION
If base url is defined as `baseurl:` or is not present at all in `_config.yml` the below exception is raised:

```
bundler: failed to load command: jekyll (~/.gem/ruby/2.4.1/bin/jekyll)
NoMethodError: undefined method `+' for nil:NilClass
~/.gem/ruby/2.4.1/gems/jekyll-multiple-languages-plugin-1.5.1/lib/jekyll-multiple-languages-plugin.rb:120:in `block in process'
~/.gem/ruby/2.4.1/gems/jekyll-multiple-languages-plugin-1.5.1/lib/jekyll-multiple-languages-plugin.rb:116:in `each'
~/.gem/ruby/2.4.1/gems/jekyll-multiple-languages-plugin-1.5.1/lib/jekyll-multiple-languages-plugin.rb:116:in `process'
~/.gem/ruby/2.4.1/gems/jekyll-3.5.2/lib/jekyll/command.rb:26:in `process_site'
~/.gem/ruby/2.4.1/gems/jekyll-3.5.2/lib/jekyll/commands/build.rb:63:in `build'
~/.gem/ruby/2.4.1/gems/jekyll-3.5.2/lib/jekyll/commands/build.rb:34:in `process'
~/.gem/ruby/2.4.1/gems/jekyll-3.5.2/lib/jekyll/commands/build.rb:16:in `block (2 levels) in init_with_program'
~/.gem/ruby/2.4.1/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `block in execute'
~/.gem/ruby/2.4.1/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `each'
~/.gem/ruby/2.4.1/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `execute'
~/.gem/ruby/2.4.1/gems/mercenary-0.3.6/lib/mercenary/program.rb:42:in `go'
~/.gem/ruby/2.4.1/gems/mercenary-0.3.6/lib/mercenary.rb:19:in `program'
~/.gem/ruby/2.4.1/gems/jekyll-3.5.2/exe/jekyll:13:in `<top (required)>'
~/.gem/ruby/2.4.1/bin/jekyll:22:in `load'
~/.gem/ruby/2.4.1/bin/jekyll:22:in `<top (required)>'
```

This PR simply converts `nil` => `''`.