### PR TITLE
fix: check if static_file_r_path is set

### DIFF
--- a/lib/jekyll-multiple-languages-plugin.rb
+++ b/lib/jekyll-multiple-languages-plugin.rb
@@ -35,7 +35,7 @@ module Jekyll
           
         # Remove "/" from beginning of static file relative path
         if static_file.instance_variable_get(:@relative_path).nil?
-          static_file_r_path    = static_file.instance_variable_get(:@relative_path).dup
+          static_file_r_path = static_file.instance_variable_get(:@relative_path).dup
           if static_file_r_path
             static_file_r_path[0] = ''
 

--- a/lib/jekyll-multiple-languages-plugin.rb
+++ b/lib/jekyll-multiple-languages-plugin.rb
@@ -34,7 +34,7 @@ module Jekyll
       static_files.delete_if do |static_file|
           
         # Remove "/" from beginning of static file relative path
-        if static_file.instance_variable_get(:@relative_path).nil?
+        if static_file.instance_variable_get(:@relative_path) != nil
           static_file_r_path = static_file.instance_variable_get(:@relative_path).dup
           if static_file_r_path
             static_file_r_path[0] = ''

--- a/lib/jekyll-multiple-languages-plugin.rb
+++ b/lib/jekyll-multiple-languages-plugin.rb
@@ -35,11 +35,13 @@ module Jekyll
           
         # Remove "/" from beginning of static file relative path
         static_file_r_path    = static_file.instance_variable_get(:@relative_path).dup
-        static_file_r_path[0] = ''
-        
-        exclude_paths.any? do |exclude_path|
-          Pathname.new(static_file_r_path).descend do |static_file_path|
-            break(true) if (Pathname.new(exclude_path) <=> static_file_path) == 0
+        if (static_file_r_path)
+          static_file_r_path[0] = ''
+
+          exclude_paths.any? do |exclude_path|
+            Pathname.new(static_file_r_path).descend do |static_file_path|
+              break(true) if (Pathname.new(exclude_path) <=> static_file_path) == 0
+            end
           end
         end
       end

--- a/lib/jekyll-multiple-languages-plugin.rb
+++ b/lib/jekyll-multiple-languages-plugin.rb
@@ -34,13 +34,15 @@ module Jekyll
       static_files.delete_if do |static_file|
           
         # Remove "/" from beginning of static file relative path
-        static_file_r_path    = static_file.instance_variable_get(:@relative_path).dup
-        if (static_file_r_path)
-          static_file_r_path[0] = ''
+        if static_file.instance_variable_get(:@relative_path).nil?
+          static_file_r_path    = static_file.instance_variable_get(:@relative_path).dup
+          if static_file_r_path
+            static_file_r_path[0] = ''
 
-          exclude_paths.any? do |exclude_path|
-            Pathname.new(static_file_r_path).descend do |static_file_path|
-              break(true) if (Pathname.new(exclude_path) <=> static_file_path) == 0
+            exclude_paths.any? do |exclude_path|
+              Pathname.new(static_file_r_path).descend do |static_file_path|
+                break(true) if (Pathname.new(exclude_path) <=> static_file_path) == 0
+              end
             end
           end
         end


### PR DESCRIPTION
As I mentioned in https://github.com/Anthony-Gaudino/jekyll-multiple-languages-plugin/issues/96 I got the following error when I was trying to run `bundle exec jekyll serve`: 
```
NoMethodError: undefined method `[]=' for nil:NilClass
  /usr/local/lib/ruby/gems/2.4.0/gems/jekyll-multiple-languages-plugin-1.5.1/lib/jekyll-multiple-languages-plugin.rb:38:in `block (2 levels) in <module:Jekyll>'
  /usr/local/lib/ruby/gems/2.4.0/gems/jekyll-multiple-languages-plugin-1.5.1/lib/jekyll-multiple-languages-plugin.rb:34:in `delete_if'
  /usr/local/lib/ruby/gems/2.4.0/gems/jekyll-multiple-languages-plugin-1.5.1/lib/jekyll-multiple-languages-plugin.rb:34:in `block in <module:Jekyll>'
  /usr/local/lib/ruby/gems/2.4.0/gems/jekyll-3.5.1/lib/jekyll/hooks.rb:98:in `block in trigger'
  /usr/local/lib/ruby/gems/2.4.0/gems/jekyll-3.5.1/lib/jekyll/hooks.rb:97:in `each'
  /usr/local/lib/ruby/gems/2.4.0/gems/jekyll-3.5.1/lib/jekyll/hooks.rb:97:in `trigger'
  /usr/local/lib/ruby/gems/2.4.0/gems/jekyll-3.5.1/lib/jekyll/site.rb:197:in `render'
  /usr/local/lib/ruby/gems/2.4.0/gems/jekyll-3.5.1/lib/jekyll/site.rb:73:in `process'
  /usr/local/lib/ruby/gems/2.4.0/gems/jekyll-multiple-languages-plugin-1.5.1/lib/jekyll-multiple-languages-plugin.rb:125:in `block in process'
  /usr/local/lib/ruby/gems/2.4.0/gems/jekyll-multiple-languages-plugin-1.5.1/lib/jekyll-multiple-languages-plugin.rb:116:in `each'
  /usr/local/lib/ruby/gems/2.4.0/gems/jekyll-multiple-languages-plugin-1.5.1/lib/jekyll-multiple-languages-plugin.rb:116:in `process'
  /usr/local/lib/ruby/gems/2.4.0/gems/jekyll-3.5.1/lib/jekyll/command.rb:26:in `process_site'
  /usr/local/lib/ruby/gems/2.4.0/gems/jekyll-3.5.1/lib/jekyll/commands/build.rb:63:in `build'
  /usr/local/lib/ruby/gems/2.4.0/gems/jekyll-3.5.1/lib/jekyll/commands/build.rb:34:in `process'
  /usr/local/lib/ruby/gems/2.4.0/gems/jekyll-3.5.1/lib/jekyll/commands/serve.rb:40:in `block (3 levels) in init_with_program'
  /usr/local/lib/ruby/gems/2.4.0/gems/jekyll-3.5.1/lib/jekyll/commands/serve.rb:40:in `each'
  /usr/local/lib/ruby/gems/2.4.0/gems/jekyll-3.5.1/lib/jekyll/commands/serve.rb:40:in `block (2 levels) in init_with_program'
  /usr/local/lib/ruby/gems/2.4.0/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `block in execute'
  /usr/local/lib/ruby/gems/2.4.0/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `each'
  /usr/local/lib/ruby/gems/2.4.0/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `execute'
  /usr/local/lib/ruby/gems/2.4.0/gems/mercenary-0.3.6/lib/mercenary/program.rb:42:in `go'
  /usr/local/lib/ruby/gems/2.4.0/gems/mercenary-0.3.6/lib/mercenary.rb:19:in `program'
  /usr/local/lib/ruby/gems/2.4.0/gems/jekyll-3.5.1/exe/jekyll:13:in `<top (required)>'
  /usr/local/bin/jekyll:23:in `load'
  /usr/local/bin/jekyll:23:in `<top (required)>'
```

And on another machine I get:
```
Error:  can't dup NilClass
```

Everything works fine for me after adding this checks.

Closes https://github.com/Anthony-Gaudino/jekyll-multiple-languages-plugin/issues/85