### PR TITLE
Added a new "localized_posts_dir" parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,13 @@ To avoid redundancy, it is possible to exclude files and folders from being copi
 ```yaml
 exclude_from_localizations: ["javascript", "images", "css"]
 ```
+
+Instead of adding all your posts under the `i18n` directory (with subfolders like: `_i18n/{sv,en,de,fr}/_posts`), you can define a custom parameter to add your posts into or keep the `_posts` directory so you will have a structure like `_posts/{sv,en,de,fr}/`, just add the following parameter:
+
+```
+localized_posts_dir: _posts
+```
+
 In code, these specific files should be referenced via `baseurl_root`. E.g.
 
 ```

--- a/lib/jekyll-multiple-languages-plugin.rb
+++ b/lib/jekyll-multiple-languages-plugin.rb
@@ -144,7 +144,11 @@ module Jekyll
         translate_posts = !self.config['exclude_from_localizations'].include?("_posts")
         
         if dir == '' && translate_posts
-          read_posts("_i18n/#{self.config['lang']}/")
+          if site.config['localized_posts_dir']
+            read_publishable(site.config['localized_posts_dir'], site.config['lang'], Document::DATE_FILENAME_MATCHER)
+          else
+            read_posts("_i18n/#{self.config['lang']}/")
+          end
         else
           read_posts_org(dir)
         end
@@ -170,7 +174,11 @@ module Jekyll
       def read_posts(dir)
         translate_posts = !site.config['exclude_from_localizations'].include?("_posts")
         if dir == '' && translate_posts
-          read_posts("_i18n/#{site.config['lang']}/")
+          if site.config['localized_posts_dir']
+            read_publishable(site.config['localized_posts_dir'], site.config['lang'], Document::DATE_FILENAME_MATCHER)
+          else
+            read_posts("_i18n/#{self.config['lang']}/")
+          end
         else
           read_posts_org(dir)
         end


### PR DESCRIPTION
Hello,

We have translated our company blog based on Jekyll and we would like to have the following post structure for managing translations:

```
| _posts
  |- en
    |- my-post-1.md
  |- fr
    |- my-post-1.md
```

That was not possible actually with your library because you were looking into `i18b/<language>/_posts` directory.

What I propose with this pull request is to add a new parameter to put into `_config.yml` file in order to be able to customize the directory where posts are located:

```yml
localized_posts_dir: _posts
```

We would really need this change, please, do not hesitate to let me know if I can achieve this better ;)

Thank you