### PR TITLE
Missing slash before lang prefix in lang picker example

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Or install it yourself as: `$ gem install jekyll-multiple-languages-plugin`
 To activate the plugin add it to the Jekyll `_config.yml` file, under the `gems` option:
 
 ```ruby
-gems: 
+gems:
   - jekyll-multiple-languages-plugin
 ```
 See the [Jekyll configuration documentation](http://jekyllrb.com/docs/configuration) for details.
@@ -286,7 +286,7 @@ This allows you to create solutions like this:
 
 ``` liquid
 {% if site.lang == "sv" %}
-  {% capture link1 %}{{ site.baseurl_root }}en{{ page.url}}{% endcapture %}
+  {% capture link1 %}{{ site.baseurl_root }}/en{{ page.url}}{% endcapture %}
   <a href="{{ link1 }}" >{% t global.english %}</a>
 {% elsif site.lang == "en" %}
   {% capture link2 %}{{ site.baseurl_root }}{{ page.url  }}{% endcapture %}


### PR DESCRIPTION
Without the slash before language prefix links are broken.

Before:
http://127.0.0.1:4000/about/
Click to change language, and you are taken to: 
http://127.0.0.1:4000/about/en/about/
which is not correct

After:
http://127.0.0.1:4000/about/
Click to change language, and you are taken to:
http://127.0.0.1:4000/en/about/
which is correct now