### PR TITLE
Build translations in `pre_render` hook

### DIFF
--- a/lib/jekyll-multiple-languages-plugin.rb
+++ b/lib/jekyll-multiple-languages-plugin.rb
@@ -22,6 +22,7 @@ module Jekyll
   Jekyll::Hooks.register :site, :pre_render do |site, payload|
       lang = site.config['lang']
       unless site.parsed_translations.has_key?(lang)
+        puts "Loading translation from file #{site.source}/_i18n/#{lang}.yml"
         site.parsed_translations[lang] = YAML.load_file("#{site.source}/_i18n/#{lang}.yml")
       end
   end

--- a/lib/jekyll-multiple-languages-plugin.rb
+++ b/lib/jekyll-multiple-languages-plugin.rb
@@ -19,6 +19,12 @@ module Jekyll
   #*****************************************************************************
   # :site, :post_render hook
   #*****************************************************************************
+  Jekyll::Hooks.register :site, :pre_render do |site, payload|
+      lang = site.config['lang']
+      unless site.parsed_translations.has_key?(lang)
+        site.parsed_translations[lang] = YAML.load_file("#{site.source}/_i18n/#{lang}.yml")
+      end
+  end
   Jekyll::Hooks.register :site, :post_render do |site, payload|
     
     # Removes all static files that should not be copied to translated sites.
@@ -304,11 +310,6 @@ module Jekyll
       site = context.registers[:site] # Jekyll site object
       
       lang = site.config['lang']
-      
-      unless site.parsed_translations.has_key?(lang)
-        puts              "Loading translation from file #{site.source}/_i18n/#{lang}.yml"
-        site.parsed_translations[lang] = YAML.load_file("#{site.source}/_i18n/#{lang}.yml")
-      end
       
       translation = site.parsed_translations[lang].access(key) if key.is_a?(String)
       


### PR DESCRIPTION
Fix against https://github.com/Anthony-Gaudino/jekyll-multiple-languages-plugin/issues/121

In order to enable `site.translations`(not `t`),  I made a fix to build `site` in `pre_render`(not `post_render`).
https://github.com/jekyll/jekyll/blob/master/lib/jekyll/site.rb#L187

